### PR TITLE
fixed #109: cannot read property querySelectorAll of null

### DIFF
--- a/src/SRL/SRLWrapper/index.js
+++ b/src/SRL/SRLWrapper/index.js
@@ -312,6 +312,10 @@ const SRLWrapper = ({
 
     // 1) Detected the type of element (if the user is using the "GALLERY" approach)
     function handleDetectTypeOfElements(array) {
+      if (!array) {
+        return;
+      }
+
       // Grabs images in the ref
       const collectedElements = array.querySelectorAll('img')
       // Filtered collected elemenets is used to exclude Gatsby images inside the <picture></picture> tag


### PR DESCRIPTION
Just prevented `handleDetectTypeOfElements` handler to run when the reference element is null - potentially due to component lifecycle