### PR TITLE
fix: script errors and potential memory leaks

### DIFF
--- a/src/SRL/SRLLightbox/SRLLightboxGallery/SRLContainer/SRLImageComponent/index.js
+++ b/src/SRL/SRLLightbox/SRLLightboxGallery/SRLContainer/SRLImageComponent/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import {
   SRLImage,
   SRLPanzoomedImage
@@ -21,12 +21,12 @@ const ImageLoad = React.memo(
   }) => {
     const [loading, setLoading] = useState(true)
 
-    function handleTouchStart(e) {
+    const handleTouchStart = useCallback((e) => {
       if (e.touches.length > 1 && !panzoomEnabled && e.cancelable) {
         e.preventDefault()
         handlePanzoom(true)
       }
-    }
+    }, [panzoomEnabled, handlePanzoom]);
 
     useEffect(() => {
       const imageToLoad = new Image()
@@ -43,11 +43,11 @@ const ImageLoad = React.memo(
       })
 
       return () => {
-        document.addEventListener('touchstart', handleTouchStart, {
+        document.removeEventListener('touchstart', handleTouchStart, {
           passive: false
         })
       }
-    }, [])
+    }, [handleTouchStart])
 
     const content = loading ? (
       <SRLLoadingIndicator />

--- a/src/SRL/SRLLightbox/SRLLightboxGallery/SRLContainer/SRLThumbnailGallery/index.js
+++ b/src/SRL/SRLLightbox/SRLLightboxGallery/SRLContainer/SRLThumbnailGallery/index.js
@@ -104,7 +104,9 @@ const SRLThumbnailGalleryComponent = ({
       }
     }
 
-    function handleMouseDownOnThumbnails(pageX, pageY) {
+    function handleMouseDownOnThumbnails(e) {
+      const { pageX, pageY } = e;
+
       if (SRLTCR.scrollWidth > SRLTCR.offsetWidth) {
         isDown.current = true
         startX.current = pageX - SRLTCR.offsetLeft
@@ -123,7 +125,9 @@ const SRLThumbnailGalleryComponent = ({
       SRLTCR.classList.remove('SRLDraggable')
     }
 
-    function handleMouseMoveOnThumbnails(pageX, pageY) {
+    function handleMouseMoveOnThumbnails(e) {
+      const { pageX, pageY } = e;
+
       if (!isDown.current) return
       if (SRLTCR.scrollHeight > SRLTCR.offsetHeight) {
         const y = pageY - SRLTCR.offsetTop
@@ -137,29 +141,17 @@ const SRLThumbnailGalleryComponent = ({
     }
 
     // EVENT LISTENERS
-    SRLTCR.addEventListener('mousedown', (e) =>
-      handleMouseDownOnThumbnails(e.pageX, e.pageY)
-    )
-    SRLTCR.addEventListener('mouseleave', () => handleMouseLeaveOnThumbnails())
-    SRLTCR.addEventListener('mouseup', () => handleMouseLeaveOnThumbnails())
-    SRLTCR.addEventListener('mousemove', (e) =>
-      handleMouseMoveOnThumbnails(e.pageX, e.pageY)
-    )
+    SRLTCR.addEventListener('mousedown', handleMouseDownOnThumbnails)
+    SRLTCR.addEventListener('mouseleave', handleMouseLeaveOnThumbnails)
+    SRLTCR.addEventListener('mouseup', handleMouseLeaveOnThumbnails)
+    SRLTCR.addEventListener('mousemove', handleMouseMoveOnThumbnails)
 
     // CLEAN UP
     return () => {
-      SRLTCR.removeEventListener('mousedown', (e) =>
-        handleMouseDownOnThumbnails(e.pageX)
-      )
-      SRLTCR.removeEventListener('mouseleave', () =>
-        handleMouseLeaveOnThumbnails()
-      )
-      SRLTCR.removeEventListener('mouseup', () =>
-        handleMouseLeaveOnThumbnails()
-      )
-      SRLTCR.removeEventListener('mousemove', (e) =>
-        handleMouseMoveOnThumbnails(e)
-      )
+      SRLTCR.removeEventListener('mousedown', handleMouseDownOnThumbnails)
+      SRLTCR.removeEventListener('mouseleave', handleMouseLeaveOnThumbnails)
+      SRLTCR.removeEventListener('mouseup', handleMouseLeaveOnThumbnails)
+      SRLTCR.removeEventListener('mousemove', handleMouseMoveOnThumbnails)
     }
   }, [currentId, handleCurrentElement, SRLThumbnailsRef, thumbnailsAlignment])
 
@@ -184,9 +176,8 @@ const SRLThumbnailGalleryComponent = ({
             thumbnailsGap={thumbnailsGap}
             key={element.id}
             id={element.id}
-            className={`SRLThumb SRLThumb${element.id} ${
-              currentId === element.id ? 'SRLThumbnailSelected' : ''
-            }`}
+            className={`SRLThumb SRLThumb${element.id} ${currentId === element.id ? 'SRLThumbnailSelected' : ''
+              }`}
             style={{
               backgroundImage: `url('${element.thumbnail}')`
             }}

--- a/src/SRL/SRLLightbox/SRLLightboxGallery/index.js
+++ b/src/SRL/SRLLightbox/SRLLightboxGallery/index.js
@@ -413,7 +413,7 @@ const SRLLightboxGallery = ({
     if (typeof window !== 'undefined') {
       document.body.classList.add('SRLOpened')
       document.body.style.marginRight = compensateForScrollbar + 'px'
-      disableBodyScroll(document.getElementsByClassName('.SRLOpened'), {
+      disableBodyScroll(document.body, {
         allowTouchMove: (el) =>
           el.className.includes('SRLThumbnailsContainer') ||
           el.className.includes('SRLThumb')


### PR DESCRIPTION
Our sentry logger reported the following error: 
```
TypeError: e.className.includes is not a function. (In 'e.className.includes("SRLThumbnailsContainer")', 'e.className.includes' is undefined)
  at allowTouchMove (/496.7.367.0.bundle.js:2:2973086)
  at None (/496.7.367.0.bundle.js:2:2967652)
  at some ([native code])
  at _d (/496.7.367.0.bundle.js:2:2967708)
  at r (/172.7.367.0.bundle.js:2:28655)
```

What I've found is that `document.getElementsByClassName('.SRLOpened')` always returns empty collection intead of element since `document.getElementsByClassName` returns array by design and expects class name without `.` sign. 
While reviewing code I've also found a couple of issues with removal of event listeners.