### PR TITLE
Fixes gallery view always downloading full size source images.

### DIFF
--- a/src/SRL/SRLWrapper/index.js
+++ b/src/SRL/SRLWrapper/index.js
@@ -211,25 +211,19 @@ const SRLWrapper = ({
                 handleAttachListener(e, element, handleElement)
                 return element
               }
-              case GALLERY_IMAGE: {
+              case GALLERY_IMAGE: {                
+                // If <img> is wrapped in <a>, then <img> src is thumbnail and <a> href is source.
+                // If <img> is not wrapped, then <img> src is both thumbnail and source.
+                // N.B. Gatsby and NextJS insert elements around <img>.
+                const parentLinkElement = e.closest("a");
+                const thumbnailUrl = e.src || e.currentSrc;
+                const sourceUrl = parentLinkElement ? parentLinkElement.href : thumbnailUrl;
+
                 const element = {
                   id: e.getAttribute('srl_elementid'),
-                  source:
-                    e.parentElement.href ||
-                    e.offsetParent.parentElement.href ||
-                    e.offsetParent.href ||
-                    e.parentElement.parentElement.parentElement.href || // UGLY FIX FOR GATSBY
-                    e.src ||
-                    e.currentSrc ||
-                    null,
+                  source: sourceUrl,
                   caption: e.alt || e.textContent,
-                  thumbnail:
-                    e.parentElement.href ||
-                    e.offsetParent.parentElement.href ||
-                    e.offsetParent.href ||
-                    e.parentElement.parentElement.parentElement.href || // UGLY FIX FOR GATSBY
-                    e.src ||
-                    e.currentSrc,
+                  thumbnail: thumbnailUrl,
                   width: null,
                   height: null,
                   type: 'gallery_image'


### PR DESCRIPTION
Closes #187 

This PR fixes the logic in `src/SRL/SRLWrapper/index.js` that parses the DOM surrounding an image element to get the `source` and `thumbnail` image URLs. Previously, the `source` URL would always be used for both if present. 

It also switches to using [`Element.closest()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest) instead of `e.parentElement.parentElement`. This means that more than one level of wrapping of the `img` can be supported. [This function is not supported in IE](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#browser_compatibility), but that's probably OK given [it's pretty much dead now](https://death-to-ie11.com/).